### PR TITLE
Fix v-autocomplete hide selected with many items does not show all items without scrolling

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -257,6 +257,12 @@ export default baseMixins.extend<options>().extend({
     internalValue (val) {
       this.initialValue = val
       this.setSelectedItems()
+
+      if (this.hideSelected) {
+        this.$nextTick(() => {
+          this.onScroll()
+        })
+      }
     },
     isMenuActive (val) {
       window.setTimeout(() => this.onMenuActiveChange(val))


### PR DESCRIPTION
fix: `#17085`
cherry-picked from `b121493`

[Cherry-Picked] fix(VSelect): update lastItem when selection changes …